### PR TITLE
Properly check for HTTPS protocol

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,7 +43,6 @@ type Config struct {
 	// ReferrerPolicy
 	// Optional. Default value "".
 	ReferrerPolicy string
-
 	// Permissions-Policy
 	// Optional. Default value "".
 	PermissionPolicy string

--- a/main.go
+++ b/main.go
@@ -80,7 +80,7 @@ func New(config ...Config) fiber.Handler {
 		if cfg.XFrameOptions != "" {
 			c.Set(fiber.HeaderXFrameOptions, cfg.XFrameOptions)
 		}
-		if c.Protocol() == "https" && cfg.HSTSMaxAge != 0 {
+		if c.Secure() && cfg.HSTSMaxAge != 0 {
 			subdomains := ""
 			if !cfg.HSTSExcludeSubdomains {
 				subdomains = "; includeSubdomains"

--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ func New(config ...Config) fiber.Handler {
 		if cfg.XFrameOptions != "" {
 			c.Set(fiber.HeaderXFrameOptions, cfg.XFrameOptions)
 		}
-		if (c.Secure() || (c.Get(fiber.HeaderXForwardedProto) == "https")) && cfg.HSTSMaxAge != 0 {
+		if c.Protocol() == "https" && cfg.HSTSMaxAge != 0 {
 			subdomains := ""
 			if !cfg.HSTSExcludeSubdomains {
 				subdomains = "; includeSubdomains"
@@ -103,7 +103,6 @@ func New(config ...Config) fiber.Handler {
 		}
 		if cfg.PermissionPolicy != "" {
 			c.Set(fiber.HeaderPermissionsPolicy, cfg.PermissionPolicy)
-
 		}
 		return c.Next()
 	}


### PR DESCRIPTION
Accessing the fiber.HeaderXForwardedProto header without verifying if we are behind a trusted proxy is susceptible to header spoofing.

Therefore, use a method which checks for this -- and more.