### PR TITLE
Fix HSTS header directive casing

### DIFF
--- a/main.go
+++ b/main.go
@@ -84,7 +84,7 @@ func New(config ...Config) fiber.Handler {
 		if (c.Secure() || (c.Get(fiber.HeaderXForwardedProto) == "https")) && cfg.HSTSMaxAge != 0 {
 			subdomains := ""
 			if !cfg.HSTSExcludeSubdomains {
-				subdomains = "; includeSubdomains"
+				subdomains = "; includeSubDomains"
 			}
 			if cfg.HSTSPreloadEnabled {
 				subdomains = fmt.Sprintf("%s; preload", subdomains)


### PR DESCRIPTION
As per RFC 6797, 6.1.2, the directive is called "includeSubDomains" with an uppercase "D" in "Domains".